### PR TITLE
feat!: v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const { createReadStream, stat } = require('fs')
 const { isAbsolute, join, basename } = require('path')
 const { promisify } = require('util')

--- a/index.js
+++ b/index.js
@@ -1,0 +1,118 @@
+const { createReadStream, stat } = require('fs')
+const { isAbsolute, join, basename } = require('path')
+const { promisify } = require('util')
+const ms = require('ms')
+const { contentType } = require('mime-types')
+const fp = require('fastify-plugin')
+const statPromise = promisify(stat)
+
+/**
+ * Options:
+ * maxAge - in seconds, max-age prop in Cache-Control
+ * root - root directory for relative filenames (default to process.cwd)
+ * lastModified - If true, pick the date from the OS of the file
+ * allowDotfiles - boolean '.<name>' files
+ * acceptRanges - enable Accept-Ranges: bytes header
+ * cacheControl - enable/disable Cache-Control header
+ * immutable - if true, sets immutable in Cache-Control, requires maxAge opt
+ */
+
+const DEFAULT_OPTIONS = {
+  acceptRanges: true,
+  allowDotfiles: false,
+  cacheControl: true,
+  maxAge: '0',
+  lastModified: true,
+  root: '',
+  immutable: false
+}
+
+function getDownload (globalOptions) {
+  const DOT_FILE_REGEX = /^\.[\w-]+/
+
+  // Merge options passed with default ones in case partial options were passed
+  globalOptions = globalOptions != null ? validateOptions(Object.assign(DEFAULT_OPTIONS, globalOptions)) : DEFAULT_OPTIONS
+
+  // Main function
+  return async function download (file, filename, options) {
+    options = validateOptions(Object.assign({}, globalOptions, typeof filename === 'object' ? filename : options))
+    filename = typeof filename === 'string' ? filename : basename(file)
+
+    const { root, allowDotfiles } = options
+    const path = validatePath(file, root, allowDotfiles)
+    const fullPath = root ? join(root, path) : path
+    const headers = getHeaders(filename, options)
+
+    if (options.lastModified) {
+      const { mtime } = await statPromise(fullPath)
+
+      this.header('Last-Modified', mtime)
+    }
+
+    const stream = createReadStream(fullPath)
+
+    this.headers(headers)
+
+    return this.send(stream)
+  }
+
+  function validateOptions (options) {
+    const { allowDotfiles, maxAge } = options
+
+    if (typeof allowDotfiles !== 'boolean') {
+      throw new Error(
+        `'dotfiles' option only accepts 'deny' or 'allow'. Received ${allowDotfiles}`
+      )
+    }
+
+    if (Number.isNaN(maxAge) && typeof maxAge !== 'string') {
+      throw new Error("'maxAge' only accepts 'numeric' or 'string' values")
+    }
+
+    return options
+  }
+
+  function validatePath (file, root, allowDotfiles) {
+    if (!isAbsolute(file) && !root) {
+      throw new Error("'file' must be absolute or specify 'root'")
+    }
+
+    if (allowDotfiles || !DOT_FILE_REGEX.test(file)) {
+      return file
+    }
+
+    throw new Error('dotfiles not allowed')
+  }
+
+  function getHeaders (filename, options) {
+    const { acceptRanges, cacheControl, immutable, maxAge } = options
+    const contentTypeHeader = contentType(filename)
+    const maxAgeArg = maxAge == null ? 0 : maxAge
+    const headers = {
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Content-Type': contentTypeHeader
+    }
+
+    if (acceptRanges) headers['Accept-Ranges'] = 'bytes'
+    if (cacheControl) {
+      const maxAgeHeader = typeof maxAgeArg === 'number' ? maxAgeArg : ms(maxAgeArg)
+      const immutableString = immutable && maxAge != null ? ', immutable' : ''
+      headers['Cache-Control'] = `max-age=${maxAgeHeader}${immutableString}`
+    }
+
+    return headers
+  }
+}
+
+function fastifyDownload (fastify, options, done) {
+  const download = getDownload(options)
+
+  fastify.decorateReply('download', download)
+
+  done()
+}
+
+module.exports = fp(fastifyDownload, {
+  fastify: '>=3.8',
+  name: 'fastify-download'
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "fastify-download",
+  "version": "0.0.0",
+  "description": "Transfers the file as an “attachment” in Fastify.",
+  "main": "index.js",
+  "scripts": {
+    "test": "tap test/*.test.js",
+    "test-ci": "tap --cov test/*.test.js && npm run typescript",
+    "lint": "standard | snazzy",
+    "lint-ci": "standard",
+    "typescript": "tsd"
+  },
+  "keywords": [
+    "fastify",
+    "fastify-plugin",
+    "fastify-download",
+    "download",
+    "content-disposition"
+  ],
+  "author": "Carlos Fuentes <carlos.fuentes.rios.95@gmail.com>",
+  "repository": {
+    "url": "https://github.com/MetCoder95/fastify-get-head"
+  },
+  "bugs": {
+    "url": "https://github.com/MetCoder95/fastify-get-head/issues"
+  },
+  "homepage": "https://github.com/MetCoder95/fastify-get-head",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^14.14.7",
+    "fastify": "^3.9.2",
+    "mock-fs": "^4.13.0",
+    "pre-commit": "^1.2.2",
+    "snazzy": "^9.0.0",
+    "standard": "^16.0.1",
+    "tap": "^12.6.6",
+    "tsd": "^0.13.1",
+    "typescript": "^4.0.2"
+  },
+  "dependencies": {
+    "fastify-plugin": "^3.0.0",
+    "mime-types": "^2.1.28",
+    "ms": "^2.1.3"
+  },
+  "tsd": {
+    "directory": "test"
+  },
+  "precommit": [
+    "lint",
+    "test"
+  ]
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,97 @@
+'use strict'
+const mock = require('mock-fs')
+const tap = require('tap')
+const test = tap.test
+// const stream = require('stream')
+const Fastify = require('fastify')
+const plugin = require('..')
+
+mock({
+  'path/to/file.png': Buffer.from('Hello-world')
+})
+
+test('Should set a decorate reply with download function', (t) => {
+  t.plan(14)
+  const server = Fastify()
+  server.register(plugin, {})
+
+  server.register(
+    function (fastifyInstance, opts, next) {
+      // GET
+      fastifyInstance.get('/string', (req, reply) => {
+        t.isNotEqual(reply.download, undefined)
+        t.strictEqual(String(reply.download), '[object Promise]')
+
+        return 'Some string'
+      })
+
+      // POST
+      fastifyInstance.post('/input', (req, reply) => {
+        t.isNotEqual(reply.download, undefined)
+        t.strictEqual(String(reply.download), '[object Promise]')
+        return { foo: 'bar' }
+      })
+
+      fastifyInstance.register(
+        function (fInstance, opts, next2) {
+          // Nested GET
+          fInstance.get('/buffer', (req, reply) => {
+            t.isNotEqual(reply.download, undefined)
+            t.strictEqual(String(reply.download), '[object Promise]')
+
+            return Buffer.from('Hello World')
+          })
+
+          next2()
+        },
+        {
+          prefix: '/with'
+        }
+      )
+
+      next()
+    },
+    { prefix: '/api' }
+  )
+
+  server.inject({ method: 'GET', url: '/api/string' }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.body, 'Some string')
+  })
+
+  server.inject({ method: 'POST', url: '/api/input' }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.deepEqual(res.json(), { foo: 'bar' })
+  })
+
+  server.inject({ method: 'GET', url: '/api/with/buffer' }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+  })
+})
+
+test('Should send a file with Content-Disposition', (t) => {
+  t.plan(14)
+  const server = Fastify()
+  server.register(plugin, {})
+
+  server.register(
+    function (fastifyInstance, opts, next) {
+      // GET
+      fastifyInstance.get('/image', (req, reply) => {
+        return reply.download('path/to/file.png')
+      })
+
+      next()
+    },
+    { prefix: '/api' }
+  )
+
+  server.inject({ method: 'GET', url: '/api/image' }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    console.log(res.headers)
+  })
+})

--- a/test/test.txf
+++ b/test/test.txf
@@ -1,0 +1,1 @@
+Hello-world!


### PR DESCRIPTION
**PR for v1**

This PR introduces v1 implementation for `fastify-download`. Which implements similar feature as `res.download` on [Express.js](https://expressjs.com/es/4x/api.html#res.download) on fastify, decorating `reply` object with a `download` function.

Closes [#1563](https://github.com/fastify/fastify/issues/1563)

**Notes**

- Not sure if is best that the `download` function should return a `Promise`. This is due to the fact that if `lastModified` flag is passed, a promisified version of `fs.stat` it's being called.

**Pending**

- [ ] Testing
- [ ] Documentation
- [ ] Types